### PR TITLE
Add ListPage component tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ npm test              # Runs Vitest in watch mode
 - Setup file: [vitest.setup.ts](vitest.setup.ts) - extends matchers and runs cleanup
 - Example: [App.test.jsx](src/App.test.jsx)
 
+**Dependency Injection for Testing:**
+- Page components accept optional API function props for testing with stubs
+- Example: [ListPage.tsx](src/components/ListPage.tsx) accepts `getWidgetsAsync` prop
+- Test example: [ListPage.test.tsx](src/components/ListPage.test.tsx) - shows how to inject stub implementations
+- Pattern: `function ListPage({ getWidgetsAsync: prop = actual })` with default parameter
+
 ### Building & Deploying
 ```bash
 npm run build         # TypeScript compile + Vite build → build/ folder

--- a/src/components/ListPage.test.tsx
+++ b/src/components/ListPage.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import ListPage from "./ListPage";
+import { WidgetCollection } from "../model/widget";
+
+// Stub implementation of getWidgetsAsync
+const stubGetWidgetsAsync = async (): Promise<WidgetCollection> => {
+  return {
+    items: [
+      { id: "1", name: "Test Widget 1", cost: 10, weight: 5 },
+      { id: "2", name: "Test Widget 2", cost: 20, weight: 10 },
+      { id: "3", name: "Test Widget 3", cost: 30, weight: 15 },
+    ],
+  };
+};
+
+test("renders list of widgets using stub", async () => {
+  render(
+    <BrowserRouter>
+      <ListPage getWidgetsAsync={stubGetWidgetsAsync} />
+    </BrowserRouter>
+  );
+
+  // Initially shows loading state
+  expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+
+  // Wait for widgets to load
+  await waitFor(() => {
+    expect(screen.getByText(/Test Widget 1/i)).toBeInTheDocument();
+  });
+
+  // Verify all widgets are rendered
+  expect(screen.getByText(/Test Widget 1/i)).toBeInTheDocument();
+  expect(screen.getByText(/Test Widget 2/i)).toBeInTheDocument();
+  expect(screen.getByText(/Test Widget 3/i)).toBeInTheDocument();
+});
+
+test("handles error from stub gracefully", async () => {
+  const errorStub = async (): Promise<WidgetCollection> => {
+    throw new Error("Network error");
+  };
+
+  render(
+    <BrowserRouter>
+      <ListPage getWidgetsAsync={errorStub} />
+    </BrowserRouter>
+  );
+
+  // Should show the Create Widget link even on error (returns empty list)
+  await waitFor(() => {
+    expect(screen.getByText(/Create Widget/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/ListPage.tsx
+++ b/src/components/ListPage.tsx
@@ -3,10 +3,14 @@ import ItemList from "./ItemList";
 import { WidgetCollection } from "../model/widget";
 import { getWidgetsAsync } from "../api/widgets";
 
-function ListPage() {
+function ListPage({ 
+  getWidgetsAsync: getWidgetsAsyncProp = getWidgetsAsync 
+}: { 
+  getWidgetsAsync?: () => Promise<WidgetCollection> 
+} = {}) {
   async function getWidgets(): Promise<WidgetCollection> {
     try {
-      return getWidgetsAsync();
+      return getWidgetsAsyncProp();
     } catch (err) {
       console.log(err);
       return { items: [] };


### PR DESCRIPTION
Change ListPage to use an optional getWidgetsAsync() function suppied by dependency injection.
Add ListPage tests that supply a stub version of getWidgetsAsync() that returns a static JSON result, or throws an error - to test error handling.